### PR TITLE
feat(recommend): phase 1+2 서빙 — TS bandit + 글로벌 풀 quota + within-category EMA rerank

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,31 @@
 - **Optional cross-encoder rerank**: BAAI/bge-reranker-base (default OFF, opt-in via mode=`hybrid_rerank`)
 - **Stateless cursor**: zlib + base64로 snapshot/offset/query_hash 인코딩. `query_id`도 cursor 안에 echo (`i` 필드).
 - **Query Understanding**: 순수 regex sanitize (`app/services/query_understanding.py:analyze`). LLM 제거됨. API contract는 `POST /search/understand` 그대로 유지.
+- **추천 서빙 (Phase 1+2)**: 카테고리 단위 Beta-Bernoulli Thompson Sampling + 글로벌 풀 quota fill + Phase 2 user_profile within-category rerank. 상태 (recommendation_global, member_category_bandit, Qdrant user_profile) 는 `recommender` 배치가 채움. 응답 contract `{"articles":[...]}` 유지.
+
+## 추천 흐름 (`/feeds` GET)
+
+1. `bandit.load_or_init` — 풀 카테고리 set 에 대해 (member_id, category_id) state 보장. 없으면 `member_interest` 기반 prior `Beta(4,1)` (선택), `Beta(1,2)` (미선택) 채워 INSERT.
+2. `bandit.sample_thetas` — Beta(α,β) sample.
+3. `bandit.allocate_quota` — softmax(theta) × 10, top-K=6 카테고리 quota 분배.
+4. `recommendation_global` 에서 카테고리별 후보 풀 `quota * 4` 가져옴 (`rank_global ASC`).
+5. **Phase 2**: `user_vector_lookup.get_user_vector(member_id)` 있으면 within-category cosine rerank (가중 0.7 글로벌 + 0.3 유사도). 없으면 글로벌 score 그대로.
+6. dedup, quota 부족시 글로벌 풀 backfill, in-response shuffle.
+7. `impression_logger.log_impressions` — `recommendation_impression` 동기 INSERT (10 row, latency 무시 가능).
+
+## Feedback (`/feeds/feedback` POST)
+
+- bite-api 가 `user_events` insert 후 fire-and-forget 으로 호출 (실패 silent).
+- `bandit.apply_reward`: incremental UPDATE α/β. 이벤트 가중치는 `services/bandit.py` 상수.
+- Phase 2 positive event (`article_in/like/archive/share`) 는 `user_vector_lookup.push_event_to_profile` 로 user_profile EMA push (decay=0.9, 첫 클릭이면 article_vec 그대로 init).
+- 배치 reconcile 이 매일 ground-truth 로 정정 — 실시간 race 무시.
+
+## ⚠️ 추천 함정
+
+- **`recommendation_global` 비어있으면** 빈 응답. recommender 배치가 한 번도 안 돌면 이 상태.
+- **응답 contract `{"articles":[...]}`** 변경 금지. bite-api 호출자에 영향. Phase 2 rerank 도입해도 contract 그대로.
+- **Qdrant `user_profile` collection** 은 recommender 배치가 만든다 (없으면 Phase 2 코드는 graceful skip 하고 글로벌 score fallback). 차원 1024.
+- **bandit incremental ↔ batch ground-truth race**: 둘 다 같은 row UPSERT. 실시간 update 가 잠깐 sweep 될 수 있지만 다음 reconcile (매일) 이 ground-truth 로 덮어씀 — 의도된 동작.
 
 ## ⚠️ 실제로 겪은 함정 (반복 금지)
 

--- a/app/api/recommend/controller.py
+++ b/app/api/recommend/controller.py
@@ -1,12 +1,15 @@
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.orm.session import Session
-from app.db import get_db
+
 from app.core.auth import verify_api_key
-from .schema import RecommendItem
+from app.db import get_db
+
+from .feedback import handle_feedback
+from .schema import FeedbackAck, FeedbackEvent, RecommendItem
 from .service import recommend_feeds
 
-
 router = APIRouter()
+
 
 @router.get("", response_model=RecommendItem, tags=["feeds"], status_code=status.HTTP_200_OK)
 async def get_recommend_feeds(
@@ -15,3 +18,17 @@ async def get_recommend_feeds(
     _api_key: str = Depends(verify_api_key),
 ):
     return recommend_feeds(db, member_id)
+
+
+@router.post(
+    "/feedback",
+    response_model=FeedbackAck,
+    tags=["feeds"],
+    status_code=status.HTTP_200_OK,
+)
+async def post_feedback(
+    event: FeedbackEvent,
+    db: Session = Depends(get_db),
+    _api_key: str = Depends(verify_api_key),
+):
+    return handle_feedback(db, event)

--- a/app/api/recommend/feedback.py
+++ b/app/api/recommend/feedback.py
@@ -1,0 +1,61 @@
+"""POST /feeds/feedback — 실시간 reward 경로.
+
+bite-api 가 user_events insert 후 fire-and-forget 호출.
+실패해도 batch reconcile (recommender) 가 다음 cycle 에 정정한다.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.services import bandit
+from app.services.user_vector_lookup import push_event_to_profile
+
+from .schema import FeedbackAck, FeedbackEvent
+
+log = logging.getLogger(__name__)
+
+# Phase 2 user_vector 갱신 트리거 이벤트 (negative 는 vector 안 섞음)
+POSITIVE_EVENTS = {"article_in", "like", "archive", "share"}
+
+
+def _resolve_category(db: Session, article_id: str) -> int | None:
+    row = db.execute(
+        text("SELECT category_id FROM article WHERE article_id = :a"),
+        {"a": article_id},
+    ).first()
+    if row is None or row[0] is None:
+        return None
+    return int(row[0])
+
+
+def handle_feedback(db: Session, ev: FeedbackEvent) -> FeedbackAck:
+    et = ev.event_type.lower()
+
+    category_id = _resolve_category(db, ev.article_id)
+    if category_id is None:
+        return FeedbackAck(accepted=False, reason="category_id not found for article")
+
+    # 1. bandit incremental update
+    bandit_updated = False
+    try:
+        bandit.apply_reward(db, ev.member_id, category_id, et)
+        bandit_updated = (et in bandit.REWARD_ALPHA) or (et in bandit.REWARD_BETA)
+    except Exception as exc:
+        log.warning("bandit apply_reward failed: %s", exc)
+
+    # 2. Phase 2 user_profile EMA push (positive 이벤트만)
+    user_vector_updated = False
+    if et in POSITIVE_EVENTS:
+        try:
+            user_vector_updated = push_event_to_profile(ev.member_id, ev.article_id)
+        except Exception as exc:
+            log.warning("user_vector push failed: %s", exc)
+
+    return FeedbackAck(
+        accepted=True,
+        bandit_updated=bandit_updated,
+        user_vector_updated=user_vector_updated,
+    )

--- a/app/api/recommend/feedback.py
+++ b/app/api/recommend/feedback.py
@@ -17,9 +17,6 @@ from .schema import FeedbackAck, FeedbackEvent
 
 log = logging.getLogger(__name__)
 
-# Phase 2 user_vector 갱신 트리거 이벤트 (negative 는 vector 안 섞음)
-POSITIVE_EVENTS = {"article_in", "like", "archive", "share"}
-
 
 def _resolve_category(db: Session, article_id: str) -> int | None:
     row = db.execute(
@@ -46,9 +43,9 @@ def handle_feedback(db: Session, ev: FeedbackEvent) -> FeedbackAck:
     except Exception as exc:
         log.warning("bandit apply_reward failed: %s", exc)
 
-    # 2. Phase 2 user_profile EMA push (positive 이벤트만)
+    # 2. Phase 2 user_profile EMA push (positive reward 이벤트만 — bandit α 신호와 동일 set)
     user_vector_updated = False
-    if et in POSITIVE_EVENTS:
+    if et in bandit.REWARD_ALPHA:
         try:
             user_vector_updated = push_event_to_profile(ev.member_id, ev.article_id)
         except Exception as exc:

--- a/app/api/recommend/schema.py
+++ b/app/api/recommend/schema.py
@@ -1,5 +1,26 @@
-from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
 
 class RecommendItem(BaseModel):
-    articles : List[str]
+    """응답 contract — bite-api 가 소비. 변경 시 cross-service 영향."""
+    articles: List[str]
+
+
+class FeedbackEvent(BaseModel):
+    """POST /feeds/feedback 요청.
+
+    bite-api 가 user_events insert 후 fire-and-forget 으로 호출.
+    실패해도 batch reconcile (recommender) 가 다음 cycle 에 정정.
+    """
+    member_id: int
+    article_id: str
+    event_type: str = Field(..., description="article_in / like / archive / share / uninterest 등")
+
+
+class FeedbackAck(BaseModel):
+    accepted: bool
+    bandit_updated: bool = False
+    user_vector_updated: bool = False
+    reason: Optional[str] = None

--- a/app/api/recommend/service.py
+++ b/app/api/recommend/service.py
@@ -1,20 +1,200 @@
-from sqlalchemy import func
+"""
+Phase 1+2 추천 서빙.
+
+흐름:
+  1. bandit state load (or lazy init from member_interest)
+  2. Beta TS sample → 각 카테고리 theta
+  3. softmax(theta) × N → 카테고리 quota 분배 (top-K 카테고리)
+  4. recommendation_global 에서 카테고리별 후보 가져옴 (rank_global ASC, quota * candidate_factor)
+  5. Phase 2: user_profile 있으면 within-category rerank by cosine(user_vec, article_vec)
+  6. dedup, position 부여, recommendation_impression 적재 후 응답
+"""
+from __future__ import annotations
+
+import logging
+import random
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from app.models.article import Article
+from app.services import bandit
+from app.services.impression_logger import log_impressions
+from app.services.user_vector_lookup import (
+    ITEM_COLLECTION,
+    _to_article_point_id,
+    cosine,
+    get_user_vector,
+)
+from app.services.qdrant_client import get_client
 
 from .schema import RecommendItem
 
+log = logging.getLogger(__name__)
+
+N_RESULTS = 10
+TOP_K_CATEGORIES = 6
+CANDIDATE_MULTIPLIER = 4  # quota * 4 만큼 카테고리 후보 가져와 rerank
+
+
+def _fetch_pool_for_categories(
+    db: Session,
+    quota: Dict[int, int],
+) -> Dict[int, List[Tuple[str, float, float]]]:
+    """
+    각 카테고리별 후보 [(article_id, score, rank_global)] 리스트.
+    rank_global ASC (글로벌 점수 높은 순) 으로 quota * CANDIDATE_MULTIPLIER 개 가져옴.
+    """
+    out: Dict[int, List[Tuple[str, float, float]]] = {}
+    if not quota:
+        return out
+
+    for cat_id, q in quota.items():
+        if q <= 0:
+            continue
+        limit = max(q, q * CANDIDATE_MULTIPLIER)
+        rows = db.execute(
+            text(
+                """
+                SELECT article_id, score, rank_global
+                FROM recommendation_global
+                WHERE category_id = :c
+                ORDER BY rank_global ASC
+                LIMIT :n
+                """
+            ),
+            {"c": int(cat_id), "n": int(limit)},
+        ).all()
+        out[cat_id] = [(str(r[0]), float(r[1]), float(r[2])) for r in rows]
+    return out
+
+
+def _fetch_article_vectors(article_ids: List[str]) -> Dict[str, np.ndarray]:
+    if not article_ids:
+        return {}
+    client = get_client()
+    point_ids = [_to_article_point_id(aid) for aid in article_ids]
+    id_to_aid = dict(zip(point_ids, article_ids))
+    out: Dict[str, np.ndarray] = {}
+    try:
+        points = client.retrieve(
+            collection_name=ITEM_COLLECTION,
+            ids=point_ids,
+            with_vectors=True,
+            with_payload=False,
+        )
+    except Exception as exc:
+        log.warning("article vector batch retrieve failed: %s", exc)
+        return {}
+    for p in points:
+        if p.vector is None:
+            continue
+        aid = id_to_aid.get(str(p.id))
+        if aid is None:
+            continue
+        out[aid] = np.asarray(p.vector, dtype=np.float32)
+    return out
+
+
+def _select_within_category(
+    candidates: List[Tuple[str, float, float]],
+    quota: int,
+    user_vec: Optional[np.ndarray],
+    article_vecs: Dict[str, np.ndarray],
+) -> List[Tuple[str, float]]:
+    """카테고리 후보 중 quota 개 선택. Phase 2 user_vec 있으면 cosine rerank."""
+    if not candidates or quota <= 0:
+        return []
+
+    if user_vec is None:
+        # Phase 1 fallback: 글로벌 score 그대로
+        return [(aid, score) for aid, score, _rank in candidates[:quota]]
+
+    scored: List[Tuple[str, float]] = []
+    for aid, score, _rank in candidates:
+        v = article_vecs.get(aid)
+        if v is None:
+            # 임베딩 missing — 글로벌 score 그대로 (낮은 우선순위)
+            scored.append((aid, score * 0.5))
+            continue
+        sim = cosine(user_vec, v)
+        # 0.7 * 글로벌 + 0.3 * 유사도
+        combined = 0.7 * score + 0.3 * (sim + 1.0) / 2.0
+        scored.append((aid, combined))
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return scored[:quota]
+
 
 def recommend_feeds(db: Session, member_id: int) -> RecommendItem:
-    del member_id
+    # 1. bandit state
+    state = bandit.load_or_init(db, member_id)
+    if not state:
+        log.info("recommendation_global 비어있음 또는 풀에 카테고리 없음 → 빈 응답")
+        return RecommendItem(articles=[])
 
-    articles = (
-        db.query(Article.article_id)
-        .filter(Article.article_id.isnot(None))
-        .order_by(func.rand())
-        .limit(10)
-        .all()
+    # 2. TS sample
+    rng = np.random.default_rng()
+    thetas = bandit.sample_thetas(state, rng=rng)
+
+    # 3. quota 분배
+    quota = bandit.allocate_quota(thetas, N_RESULTS, top_k_categories=TOP_K_CATEGORIES)
+    if not quota:
+        return RecommendItem(articles=[])
+
+    # 4. category 후보 풀
+    by_category = _fetch_pool_for_categories(db, quota)
+
+    # 5. Phase 2 user vector
+    user_vec = get_user_vector(member_id)
+    all_candidate_ids: List[str] = []
+    for cat_id, cands in by_category.items():
+        all_candidate_ids.extend([aid for aid, _, _ in cands])
+    article_vecs: Dict[str, np.ndarray] = (
+        _fetch_article_vectors(all_candidate_ids) if user_vec is not None and all_candidate_ids else {}
     )
 
-    return RecommendItem(articles=[row[0] for row in articles])
+    # 6. 카테고리별 select
+    selected: List[Tuple[str, int, float]] = []  # (article_id, category_id, theta)
+    seen_ids = set()
+    for cat_id, q in quota.items():
+        cands = by_category.get(cat_id, [])
+        chosen = _select_within_category(cands, q, user_vec, article_vecs)
+        for aid, _ in chosen:
+            if aid in seen_ids:
+                continue
+            seen_ids.add(aid)
+            selected.append((aid, int(cat_id), float(thetas.get(cat_id, 0.0))))
+
+    # quota 부족 → 글로벌 풀로 backfill (top by rank_global)
+    if len(selected) < N_RESULTS:
+        fill_n = N_RESULTS - len(selected)
+        rows = db.execute(
+            text(
+                "SELECT article_id, category_id FROM recommendation_global "
+                "ORDER BY rank_global ASC LIMIT :n"
+            ),
+            {"n": fill_n + len(seen_ids)},
+        ).all()
+        for r in rows:
+            aid = str(r[0])
+            if aid in seen_ids:
+                continue
+            cid = int(r[1]) if r[1] is not None else None
+            theta_val = float(thetas.get(cid, 0.0)) if cid is not None else 0.0
+            selected.append((aid, cid if cid is not None else 0, theta_val))
+            seen_ids.add(aid)
+            if len(selected) >= N_RESULTS:
+                break
+
+    # 응답 내 셔플 (같은 유저가 매번 같은 순서를 보지 않도록 — 단 quota 비례는 유지)
+    rng.shuffle(selected)
+
+    # 7. impression log
+    impression_rows = [
+        (aid, (cid if cid != 0 else None), pos + 1, theta)
+        for pos, (aid, cid, theta) in enumerate(selected)
+    ]
+    log_impressions(db, member_id, impression_rows)
+
+    return RecommendItem(articles=[aid for aid, _, _ in selected])

--- a/app/api/recommend/service.py
+++ b/app/api/recommend/service.py
@@ -16,13 +16,13 @@ import random
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 from sqlalchemy.orm import Session
 
+from app.core.config import config
 from app.services import bandit
 from app.services.impression_logger import log_impressions
 from app.services.user_vector_lookup import (
-    ITEM_COLLECTION,
     _to_article_point_id,
     cosine,
     get_user_vector,
@@ -38,35 +38,44 @@ TOP_K_CATEGORIES = 6
 CANDIDATE_MULTIPLIER = 4  # quota * 4 만큼 카테고리 후보 가져와 rerank
 
 
+_POOL_BY_CATEGORY_SQL = text(
+    """
+    SELECT article_id, score, rank_global, category_id
+    FROM (
+      SELECT
+        article_id, score, rank_global, category_id,
+        ROW_NUMBER() OVER (PARTITION BY category_id ORDER BY rank_global ASC) AS rn
+      FROM recommendation_global
+      WHERE category_id IN :cats
+    ) t
+    WHERE rn <= :n
+    """
+).bindparams(bindparam("cats", expanding=True))
+
+
 def _fetch_pool_for_categories(
     db: Session,
     quota: Dict[int, int],
+    multiplier: int,
 ) -> Dict[int, List[Tuple[str, float, float]]]:
     """
-    각 카테고리별 후보 [(article_id, score, rank_global)] 리스트.
-    rank_global ASC (글로벌 점수 높은 순) 으로 quota * CANDIDATE_MULTIPLIER 개 가져옴.
+    카테고리별 후보 [(article_id, score, rank_global)] 단일 쿼리.
+    multiplier=1 (rerank 없음, quota 만큼) / >1 (rerank 용 더 가져옴).
     """
-    out: Dict[int, List[Tuple[str, float, float]]] = {}
     if not quota:
-        return out
+        return {}
 
-    for cat_id, q in quota.items():
-        if q <= 0:
-            continue
-        limit = max(q, q * CANDIDATE_MULTIPLIER)
-        rows = db.execute(
-            text(
-                """
-                SELECT article_id, score, rank_global
-                FROM recommendation_global
-                WHERE category_id = :c
-                ORDER BY rank_global ASC
-                LIMIT :n
-                """
-            ),
-            {"c": int(cat_id), "n": int(limit)},
-        ).all()
-        out[cat_id] = [(str(r[0]), float(r[1]), float(r[2])) for r in rows]
+    cat_ids = [c for c, q in quota.items() if q > 0]
+    if not cat_ids:
+        return {}
+
+    max_per_cat = max(quota[c] for c in cat_ids) * max(1, multiplier)
+    rows = db.execute(_POOL_BY_CATEGORY_SQL, {"cats": cat_ids, "n": int(max_per_cat)}).all()
+
+    out: Dict[int, List[Tuple[str, float, float]]] = {c: [] for c in cat_ids}
+    for r in rows:
+        cid = int(r[3])
+        out.setdefault(cid, []).append((str(r[0]), float(r[1]), float(r[2])))
     return out
 
 
@@ -79,7 +88,7 @@ def _fetch_article_vectors(article_ids: List[str]) -> Dict[str, np.ndarray]:
     out: Dict[str, np.ndarray] = {}
     try:
         points = client.retrieve(
-            collection_name=ITEM_COLLECTION,
+            collection_name=config.QDRANT_COLLECTION_NAME,
             ids=point_ids,
             with_vectors=True,
             with_payload=False,
@@ -142,21 +151,22 @@ def recommend_feeds(db: Session, member_id: int) -> RecommendItem:
     if not quota:
         return RecommendItem(articles=[])
 
-    # 4. category 후보 풀
-    by_category = _fetch_pool_for_categories(db, quota)
-
-    # 5. Phase 2 user vector
+    # 4. Phase 2 user vector — 있으면 within-category rerank 위해 4배 가져오기, 없으면 quota 만큼
     user_vec = get_user_vector(member_id)
-    all_candidate_ids: List[str] = []
-    for cat_id, cands in by_category.items():
-        all_candidate_ids.extend([aid for aid, _, _ in cands])
-    article_vecs: Dict[str, np.ndarray] = (
-        _fetch_article_vectors(all_candidate_ids) if user_vec is not None and all_candidate_ids else {}
-    )
+    multiplier = CANDIDATE_MULTIPLIER if user_vec is not None else 1
+    by_category = _fetch_pool_for_categories(db, quota, multiplier=multiplier)
 
-    # 6. 카테고리별 select
-    selected: List[Tuple[str, int, float]] = []  # (article_id, category_id, theta)
-    seen_ids = set()
+    article_vecs: Dict[str, np.ndarray] = {}
+    if user_vec is not None:
+        all_candidate_ids: List[str] = []
+        for cands in by_category.values():
+            all_candidate_ids.extend(aid for aid, _, _ in cands)
+        if all_candidate_ids:
+            article_vecs = _fetch_article_vectors(all_candidate_ids)
+
+    # 5. 카테고리별 select
+    selected: List[Tuple[str, Optional[int], float]] = []
+    seen_ids: set[str] = set()
     for cat_id, q in quota.items():
         cands = by_category.get(cat_id, [])
         chosen = _select_within_category(cands, q, user_vec, article_vecs)
@@ -164,7 +174,7 @@ def recommend_feeds(db: Session, member_id: int) -> RecommendItem:
             if aid in seen_ids:
                 continue
             seen_ids.add(aid)
-            selected.append((aid, int(cat_id), float(thetas.get(cat_id, 0.0))))
+            selected.append((aid, cat_id, float(thetas.get(cat_id, 0.0))))
 
     # quota 부족 → 글로벌 풀로 backfill (top by rank_global)
     if len(selected) < N_RESULTS:
@@ -182,17 +192,16 @@ def recommend_feeds(db: Session, member_id: int) -> RecommendItem:
                 continue
             cid = int(r[1]) if r[1] is not None else None
             theta_val = float(thetas.get(cid, 0.0)) if cid is not None else 0.0
-            selected.append((aid, cid if cid is not None else 0, theta_val))
+            selected.append((aid, cid, theta_val))
             seen_ids.add(aid)
             if len(selected) >= N_RESULTS:
                 break
 
-    # 응답 내 셔플 (같은 유저가 매번 같은 순서를 보지 않도록 — 단 quota 비례는 유지)
     rng.shuffle(selected)
 
-    # 7. impression log
+    # 6. impression log (Optional cid 그대로 전달 — DB 컬럼 NULL 허용)
     impression_rows = [
-        (aid, (cid if cid != 0 else None), pos + 1, theta)
+        (aid, cid, pos + 1, theta)
         for pos, (aid, cid, theta) in enumerate(selected)
     ]
     log_impressions(db, member_id, impression_rows)

--- a/app/services/bandit.py
+++ b/app/services/bandit.py
@@ -7,8 +7,9 @@ Lazy init: 첫 호출 시 member_interest 기반 prior 채워 INSERT.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 from sqlalchemy import text
@@ -50,11 +51,23 @@ def _fetch_member_interests(db: Session, member_id: int) -> List[int]:
     return [int(r[0]) for r in rows]
 
 
+# 글로벌 풀은 매일 1회 swap. 카테고리 set 만 알면 되므로 process-level TTL 캐시.
+_POOL_CAT_TTL_SEC = 300
+_pool_cat_cache: Tuple[float, List[int]] = (0.0, [])
+
+
 def _fetch_pool_categories(db: Session) -> List[int]:
+    global _pool_cat_cache
+    now = time.time()
+    cached_at, cached = _pool_cat_cache
+    if cached and (now - cached_at) < _POOL_CAT_TTL_SEC:
+        return cached
     rows = db.execute(
         text("SELECT DISTINCT category_id FROM recommendation_global WHERE category_id IS NOT NULL")
     ).all()
-    return [int(r[0]) for r in rows]
+    fresh = [int(r[0]) for r in rows]
+    _pool_cat_cache = (now, fresh)
+    return fresh
 
 
 def _fetch_existing_state(db: Session, member_id: int) -> Dict[int, BanditRow]:

--- a/app/services/bandit.py
+++ b/app/services/bandit.py
@@ -1,0 +1,185 @@
+"""Per-(member, category) Beta Thompson Sampling.
+
+Lazy init: 첫 호출 시 member_interest 기반 prior 채워 INSERT.
+실시간 reward update: feedback endpoint에서 incremental.
+배치 reconcile (recommender) 가 매일 ground-truth 로 overwrite.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+log = logging.getLogger(__name__)
+
+# Prior 강도 — recommender/config.yml 과 동기화. 변경 시 양쪽 같이.
+PRIOR_ALPHA_ONBOARDING = 4.0
+PRIOR_BETA_ONBOARDING = 1.0
+PRIOR_ALPHA_DEFAULT = 1.0
+PRIOR_BETA_DEFAULT = 2.0
+
+# Reward delta per event_type. uninterest 는 β 증가, 그 외는 α 증가.
+REWARD_ALPHA: Dict[str, float] = {
+    "article_in": 1.0,
+    "like": 1.0,
+    "archive": 1.0,
+    "share": 2.0,
+}
+REWARD_BETA: Dict[str, float] = {
+    "uninterest": 2.0,
+}
+
+
+@dataclass
+class BanditRow:
+    member_id: int
+    category_id: int
+    alpha: float
+    beta: float
+
+
+def _fetch_member_interests(db: Session, member_id: int) -> List[int]:
+    rows = db.execute(
+        text("SELECT interest_id FROM member_interest WHERE member_id = :m"),
+        {"m": member_id},
+    ).all()
+    return [int(r[0]) for r in rows]
+
+
+def _fetch_pool_categories(db: Session) -> List[int]:
+    rows = db.execute(
+        text("SELECT DISTINCT category_id FROM recommendation_global WHERE category_id IS NOT NULL")
+    ).all()
+    return [int(r[0]) for r in rows]
+
+
+def _fetch_existing_state(db: Session, member_id: int) -> Dict[int, BanditRow]:
+    rows = db.execute(
+        text("SELECT category_id, alpha, beta FROM member_category_bandit WHERE member_id = :m"),
+        {"m": member_id},
+    ).all()
+    return {
+        int(r[0]): BanditRow(
+            member_id=member_id, category_id=int(r[0]), alpha=float(r[1]), beta=float(r[2])
+        )
+        for r in rows
+    }
+
+
+def _lazy_init(db: Session, member_id: int, categories: Iterable[int]) -> Dict[int, BanditRow]:
+    """member_category_bandit 에 prior 로 row 채워넣고 반환."""
+    onboarding = set(_fetch_member_interests(db, member_id))
+    rows: List[Dict] = []
+    out: Dict[int, BanditRow] = {}
+    for cid in categories:
+        if cid in onboarding:
+            a, b = PRIOR_ALPHA_ONBOARDING, PRIOR_BETA_ONBOARDING
+        else:
+            a, b = PRIOR_ALPHA_DEFAULT, PRIOR_BETA_DEFAULT
+        rows.append({"m": member_id, "c": int(cid), "a": a, "b": b})
+        out[int(cid)] = BanditRow(member_id, int(cid), a, b)
+
+    if rows:
+        db.execute(
+            text(
+                """
+                INSERT INTO member_category_bandit (member_id, category_id, alpha, beta)
+                VALUES (:m, :c, :a, :b)
+                ON DUPLICATE KEY UPDATE alpha = alpha
+                """
+            ),
+            rows,
+        )
+        db.commit()
+    return out
+
+
+def load_or_init(db: Session, member_id: int) -> Dict[int, BanditRow]:
+    """현재 풀에 있는 카테고리 모두에 대해 (member_id, category_id) state 보장."""
+    pool_categories = _fetch_pool_categories(db)
+    if not pool_categories:
+        return {}
+
+    existing = _fetch_existing_state(db, member_id)
+    missing = [c for c in pool_categories if c not in existing]
+    if missing:
+        new_rows = _lazy_init(db, member_id, missing)
+        existing.update(new_rows)
+    # 풀에 있는 카테고리만 반환 (drop된 카테고리는 무시)
+    return {cid: existing[cid] for cid in pool_categories if cid in existing}
+
+
+def sample_thetas(state: Dict[int, BanditRow], rng: Optional[np.random.Generator] = None) -> Dict[int, float]:
+    """Beta(α, β) sample per category."""
+    if rng is None:
+        rng = np.random.default_rng()
+    return {cid: float(rng.beta(row.alpha, row.beta)) for cid, row in state.items()}
+
+
+def allocate_quota(thetas: Dict[int, float], n_results: int, top_k_categories: int = 6) -> Dict[int, int]:
+    """
+    softmax(theta) → quota proportions → integer rounding (sum = n_results).
+
+    상위 K 카테고리만 추출해서 quota 분배 (long-tail 다이버시티는 글로벌 풀 빌드 단계에서 보장됨).
+    rounding 잔차는 가장 큰 fractional remainder 카테고리에 할당.
+    """
+    if not thetas or n_results <= 0:
+        return {}
+
+    items = sorted(thetas.items(), key=lambda kv: kv[1], reverse=True)[:top_k_categories]
+    cats = [c for c, _ in items]
+    vals = np.asarray([v for _, v in items], dtype=np.float64)
+
+    # softmax (temperature=1)
+    e = np.exp(vals - vals.max())
+    probs = e / e.sum()
+
+    raw = probs * n_results
+    base = np.floor(raw).astype(int)
+    remaining = n_results - int(base.sum())
+    if remaining > 0:
+        # 가장 큰 fractional remainder 부터 1씩
+        frac = raw - base
+        order = np.argsort(-frac)
+        for i in order[:remaining]:
+            base[i] += 1
+
+    # 0 quota 카테고리 drop
+    return {cats[i]: int(base[i]) for i in range(len(cats)) if base[i] > 0}
+
+
+def apply_reward(db: Session, member_id: int, category_id: int, event_type: str) -> None:
+    """실시간 incremental update. 이벤트 타입별 α/β delta 적용."""
+    et = event_type.lower()
+    da = REWARD_ALPHA.get(et, 0.0)
+    db_ = REWARD_BETA.get(et, 0.0)
+    if da == 0.0 and db_ == 0.0:
+        return
+
+    db.execute(
+        text(
+            """
+            INSERT INTO member_category_bandit (member_id, category_id, alpha, beta, clicks)
+            VALUES (:m, :c, :pa, :pb, :clk)
+            ON DUPLICATE KEY UPDATE
+                alpha  = alpha + :da,
+                beta   = beta  + :db_,
+                clicks = clicks + :clk
+            """
+        ),
+        {
+            "m": int(member_id),
+            "c": int(category_id),
+            # 새로 만들 때 prior + delta (existing이면 ON DUPLICATE 분기)
+            "pa": (PRIOR_ALPHA_DEFAULT + da),
+            "pb": (PRIOR_BETA_DEFAULT + db_),
+            "da": da,
+            "db_": db_,
+            "clk": 1 if et in REWARD_ALPHA else 0,
+        },
+    )
+    db.commit()

--- a/app/services/impression_logger.py
+++ b/app/services/impression_logger.py
@@ -54,5 +54,5 @@ def log_impressions(
         try:
             db.rollback()
         except Exception:
-            pass
+            log.debug("impression log rollback skipped", exc_info=True)
         return 0

--- a/app/services/impression_logger.py
+++ b/app/services/impression_logger.py
@@ -1,0 +1,58 @@
+"""recommendation_impression 적재.
+
+응답 직전 동기 INSERT (latency 안 큼: 10 row, single tx). 실패는 graceful skip.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Optional, Tuple
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+log = logging.getLogger(__name__)
+
+
+def log_impressions(
+    db: Session,
+    member_id: int,
+    rows: Iterable[Tuple[str, Optional[int], int, Optional[float]]],
+) -> int:
+    """
+    rows: iterable of (article_id, category_id, position, bandit_theta).
+    position 은 1..N (1-base).
+    Returns inserted row count.
+    """
+    payload: List[dict] = [
+        {
+            "m": int(member_id),
+            "a": str(article_id),
+            "c": int(category_id) if category_id is not None else None,
+            "p": int(position),
+            "t": float(theta) if theta is not None else None,
+        }
+        for article_id, category_id, position, theta in rows
+    ]
+    if not payload:
+        return 0
+
+    try:
+        db.execute(
+            text(
+                """
+                INSERT INTO recommendation_impression
+                    (member_id, article_id, category_id, position, bandit_theta)
+                VALUES (:m, :a, :c, :p, :t)
+                """
+            ),
+            payload,
+        )
+        db.commit()
+        return len(payload)
+    except Exception as exc:
+        log.warning("impression log failed: %s", exc)
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        return 0

--- a/app/services/user_vector_lookup.py
+++ b/app/services/user_vector_lookup.py
@@ -11,13 +11,17 @@ from typing import Optional
 
 import numpy as np
 
+from app.core.config import config
 from app.services.qdrant_client import get_client
 
 log = logging.getLogger(__name__)
 
 USER_PROFILE_COLLECTION = "user_profile"
-ITEM_COLLECTION = "bite-vectordb"  # article 임베딩 origin
-EMA_DECAY = 0.9  # incremental EMA: new = decay * old + (1 - decay) * article_vec
+# 실시간 incremental EMA: new = decay * old + (1 - decay) * article_vec.
+# Note: recommender 배치 측 (data/pipeline/user_vector.py) 는 시간 가중 EMA (weight = decay^days)
+# — 의미가 다르므로 값(0.9 vs 0.95)도 다름. 둘이 같은 collection (`user_profile`) 을 채우되
+# 배치가 ground-truth 로 매일 overwrite, 실시간은 그 사이 incremental.
+EMA_DECAY = 0.9
 UUID_NAMESPACE = uuid.NAMESPACE_DNS
 
 
@@ -67,7 +71,7 @@ def push_event_to_profile(member_id: int, article_id: str) -> bool:
     aid = _to_article_point_id(article_id)
     try:
         art_points = client.retrieve(
-            collection_name=ITEM_COLLECTION,
+            collection_name=config.QDRANT_COLLECTION_NAME,
             ids=[aid],
             with_vectors=True,
             with_payload=False,

--- a/app/services/user_vector_lookup.py
+++ b/app/services/user_vector_lookup.py
@@ -1,0 +1,118 @@
+"""Phase 2: Qdrant `user_profile` collection 에서 user vector retrieve.
+
+배치 (recommender) 가 채우고, feedback endpoint 가 incremental EMA push 한다.
+이 모듈은 read-only lookup + EMA push 두 가지 동작.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Optional
+
+import numpy as np
+
+from app.services.qdrant_client import get_client
+
+log = logging.getLogger(__name__)
+
+USER_PROFILE_COLLECTION = "user_profile"
+ITEM_COLLECTION = "bite-vectordb"  # article 임베딩 origin
+EMA_DECAY = 0.9  # incremental EMA: new = decay * old + (1 - decay) * article_vec
+UUID_NAMESPACE = uuid.NAMESPACE_DNS
+
+
+def _to_article_point_id(article_id: str) -> str:
+    return str(uuid.uuid5(UUID_NAMESPACE, article_id))
+
+
+def get_user_vector(member_id: int) -> Optional[np.ndarray]:
+    """user_profile collection 에서 vector retrieve. 없으면 None."""
+    client = get_client()
+    try:
+        points = client.retrieve(
+            collection_name=USER_PROFILE_COLLECTION,
+            ids=[int(member_id)],
+            with_vectors=True,
+            with_payload=False,
+        )
+    except Exception as exc:
+        msg = str(exc).lower()
+        if "not found" in msg or "doesn't exist" in msg:
+            return None
+        log.warning("user_profile retrieve failed for member %s: %s", member_id, exc)
+        return None
+    if not points:
+        return None
+    p = points[0]
+    if p.vector is None:
+        return None
+    return np.asarray(p.vector, dtype=np.float32)
+
+
+def _l2_normalize(v: np.ndarray) -> np.ndarray:
+    n = float(np.linalg.norm(v))
+    if n <= 0:
+        return v.astype(np.float32)
+    return (v / n).astype(np.float32)
+
+
+def push_event_to_profile(member_id: int, article_id: str) -> bool:
+    """
+    실시간 incremental EMA. 이 article 임베딩을 user vector 에 섞는다.
+    기존 user_profile 있으면 EMA, 없으면 article_vec 그대로.
+    """
+    client = get_client()
+
+    # 1. fetch article vector
+    aid = _to_article_point_id(article_id)
+    try:
+        art_points = client.retrieve(
+            collection_name=ITEM_COLLECTION,
+            ids=[aid],
+            with_vectors=True,
+            with_payload=False,
+        )
+    except Exception as exc:
+        log.warning("article vector retrieve failed (%s): %s", article_id, exc)
+        return False
+    if not art_points or art_points[0].vector is None:
+        return False
+    article_vec = np.asarray(art_points[0].vector, dtype=np.float32)
+
+    # 2. fetch existing user vector
+    old_vec = get_user_vector(member_id)
+    if old_vec is None:
+        new_vec = _l2_normalize(article_vec)
+    else:
+        mixed = EMA_DECAY * old_vec + (1.0 - EMA_DECAY) * article_vec
+        new_vec = _l2_normalize(mixed)
+
+    # 3. upsert (ensure collection 은 batch 가 만든다 — 없으면 fail 후 fallback)
+    from qdrant_client.http import models as qm
+    try:
+        client.upsert(
+            collection_name=USER_PROFILE_COLLECTION,
+            points=[
+                qm.PointStruct(
+                    id=int(member_id),
+                    vector=new_vec.tolist(),
+                    payload={"member_id": int(member_id)},
+                )
+            ],
+        )
+        return True
+    except Exception as exc:
+        msg = str(exc).lower()
+        if "doesn't exist" in msg or "not found" in msg:
+            log.info("user_profile collection 미존재 — recommender 배치가 만들 때까지 skip")
+            return False
+        log.warning("user_profile upsert failed (member %s): %s", member_id, exc)
+        return False
+
+
+def cosine(a: np.ndarray, b: np.ndarray) -> float:
+    na = float(np.linalg.norm(a))
+    nb = float(np.linalg.norm(b))
+    if na <= 0 or nb <= 0:
+        return 0.0
+    return float(np.dot(a, b) / (na * nb))


### PR DESCRIPTION
## Summary
- /feeds 의 ORDER BY rand() placeholder → 카테고리 단위 Thompson Sampling + recommendation_global quota fill + Phase 2 user_profile cosine rerank. 응답 contract `{"articles":[...]}` 유지.
- 신규 services: bandit (TS sampler + lazy init + apply_reward), user_vector_lookup (Phase 2 EMA push), impression_logger.
- 신규 endpoint: POST /feeds/feedback. bite-api 가 user_events insert 후 fire-and-forget 호출.
- simplify: ROW_NUMBER 단일 쿼리, _fetch_pool_categories TTL 캐시 (300s), 이벤트 키 single source.
- ITEM_COLLECTION 하드코딩 → config.QDRANT_COLLECTION_NAME.

## Cross-repo PRs
- infra: bite-sized-knowledge/infra#5
- recommender: bite-sized-knowledge/recommender#6
- bite-api: bite-sized-knowledge/bite-api#6

## Test plan
- [x] dev 한 사이클 통과: recommend_feeds(member=1) 10 article, bandit lazy-init 12 cat, impression 10 row, handle_feedback α 1.0→2.0
- [x] AST/syntax check 통과
- [ ] dev 컨테이너 띄워 HTTP e2e (별도)