### PR TITLE
feat(recommend): X-Interest-Ids prior + migrate-device + backfill/latency 적재

### DIFF
--- a/app/api/recommend/controller.py
+++ b/app/api/recommend/controller.py
@@ -1,8 +1,12 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel, Field
 from sqlalchemy.orm.session import Session
 
 from app.core.auth import verify_api_key
 from app.db import get_db
+from app.services import bandit
 
 from .feedback import handle_feedback
 from .schema import FeedbackAck, FeedbackEvent, RecommendItem
@@ -12,18 +16,37 @@ from .service import recommend_feeds, recommend_feeds_anonymous
 router = APIRouter()
 
 
+def _parse_interest_ids(raw: Optional[str]) -> Optional[List[int]]:
+    """X-Interest-Ids CSV → [int]. invalid 항목은 무시. 결과 비면 None."""
+    if not raw:
+        return None
+    out: List[int] = []
+    for tok in raw.split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        try:
+            out.append(int(tok))
+        except ValueError:
+            continue
+    return out or None
+
+
 @router.get("", response_model=RecommendItem, tags=["feeds"], status_code=status.HTTP_200_OK)
 async def get_recommend_feeds(
     member_id: int | None = None,
     device_id: str | None = None,
     lang: str | None = None,
+    x_interest_ids: str | None = Header(default=None, alias="X-Interest-Ids"),
     db: Session = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
 ):
     if member_id is None and not device_id:
         raise HTTPException(status_code=400, detail="member_id or device_id is required")
     if member_id is None:
-        return recommend_feeds_anonymous(db, device_id, lang=lang)
+        return recommend_feeds_anonymous(
+            db, device_id, lang=lang, interest_ids=_parse_interest_ids(x_interest_ids)
+        )
     return recommend_feeds(db, member_id, lang=lang)
 
 
@@ -39,3 +62,32 @@ async def post_feedback(
     _api_key: str = Depends(verify_api_key),
 ):
     return handle_feedback(db, event)
+
+
+class MigrateDeviceRequest(BaseModel):
+    member_id: int = Field(..., gt=0)
+    device_id: str = Field(..., min_length=1)
+
+
+class MigrateDeviceAck(BaseModel):
+    migrated: int
+
+
+@router.post(
+    "/migrate-device",
+    response_model=MigrateDeviceAck,
+    tags=["feeds"],
+    status_code=status.HTTP_200_OK,
+)
+async def post_migrate_device(
+    payload: MigrateDeviceRequest,
+    db: Session = Depends(get_db),
+    _api_key: str = Depends(verify_api_key),
+):
+    """비회원 device 가 lazy guest 로 회원 전환된 직후 bandit state 이관.
+
+    bite-api LazyGuest middleware 가 발급 직후 fire-and-forget 호출.
+    멱등 (재호출 시 device 값으로 덮어씀, impressions/clicks 는 누적).
+    """
+    n = bandit.migrate_device_to_member(db, payload.device_id, payload.member_id)
+    return MigrateDeviceAck(migrated=n)

--- a/app/api/recommend/controller.py
+++ b/app/api/recommend/controller.py
@@ -15,6 +15,8 @@ from .service import recommend_feeds, recommend_feeds_anonymous
 
 router = APIRouter()
 
+HEADER_INTEREST_IDS = "X-Interest-Ids"
+
 
 def _parse_interest_ids(raw: Optional[str]) -> Optional[List[int]]:
     """X-Interest-Ids CSV → [int]. invalid 항목은 무시. 결과 비면 None."""
@@ -37,7 +39,7 @@ async def get_recommend_feeds(
     member_id: int | None = None,
     device_id: str | None = None,
     lang: str | None = None,
-    x_interest_ids: str | None = Header(default=None, alias="X-Interest-Ids"),
+    x_interest_ids: str | None = Header(default=None, alias=HEADER_INTEREST_IDS),
     db: Session = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
 ):

--- a/app/api/recommend/service.py
+++ b/app/api/recommend/service.py
@@ -208,8 +208,12 @@ def _serve(
     member_id: Optional[int],
     device_id: Optional[str],
     lang: Optional[str],
+    interest_ids: Optional[List[int]] = None,
 ) -> RecommendItem:
-    """회원/비회원 공통 서빙 흐름. anonymous 는 bandit 만 device 테이블."""
+    """회원/비회원 공통 서빙 흐름. anonymous 는 bandit 만 device 테이블.
+
+    interest_ids 는 비회원 lazy init 시 prior 강화에만 사용 (회원은 member_interest 가 ground truth).
+    """
     started = time.perf_counter()
     is_anonymous = member_id is None
     rng = np.random.default_rng()
@@ -221,7 +225,7 @@ def _serve(
 
     # 1. bandit state
     if is_anonymous:
-        state = bandit.load_or_init_device(db, device_id)  # type: ignore[arg-type]
+        state = bandit.load_or_init_device(db, device_id, interest_ids=interest_ids)  # type: ignore[arg-type]
     else:
         state = bandit.load_or_init(db, int(member_id))
     if not state:
@@ -302,5 +306,12 @@ def recommend_feeds_anonymous(
     db: Session,
     device_id: str,
     lang: Optional[str] = None,
+    interest_ids: Optional[List[int]] = None,
 ) -> RecommendItem:
-    return _serve(db, member_id=None, device_id=str(device_id), lang=lang)
+    return _serve(
+        db,
+        member_id=None,
+        device_id=str(device_id),
+        lang=lang,
+        interest_ids=interest_ids,
+    )

--- a/app/api/recommend/service.py
+++ b/app/api/recommend/service.py
@@ -266,11 +266,9 @@ def _serve(
             seen.add(aid)
             selected.append((aid, cat_id, float(thetas.get(cat_id, 0.0)), False))
 
-    # 6. quota 부족 → weighted random backfill (이 row 들은 backfilled=true)
-    response_was_backfilled = False
+    # 6. quota 부족 → weighted random backfill (이 row 들은 backfilled=true, admin diag 카운터도 ↑)
     if len(selected) < N_RESULTS:
         _request_metrics["backfilled"] += 1
-        response_was_backfilled = True
         for aid, cid in _backfill(db, N_RESULTS - len(selected), seen, lang, rng):
             theta = float(thetas.get(cid, 0.0)) if cid is not None else 0.0
             selected.append((aid, cid, theta, True))
@@ -294,7 +292,6 @@ def _serve(
     )
 
     _record_latency(latency_ms)
-    _ = response_was_backfilled  # 응답 단위 flag 는 admin/diagnostics 누적 카운터로만 사용
     return RecommendItem(articles=[aid for aid, _, _, _ in selected], feed_request_id=feed_request_id)
 
 

--- a/app/api/recommend/service.py
+++ b/app/api/recommend/service.py
@@ -255,8 +255,8 @@ def _serve(
         if all_ids:
             article_vecs = _fetch_article_vectors(all_ids)
 
-    # 5. 카테고리별 select
-    selected: List[Tuple[str, Optional[int], float]] = []
+    # 5. 카테고리별 select — backfilled flag 같이 추적 (per-row)
+    selected: List[Tuple[str, Optional[int], float, bool]] = []
     seen: set[str] = set()
     for cat_id, q in quota.items():
         chosen = _select_within_category(by_category.get(cat_id, []), q, user_vec, article_vecs)
@@ -264,23 +264,25 @@ def _serve(
             if aid in seen:
                 continue
             seen.add(aid)
-            selected.append((aid, cat_id, float(thetas.get(cat_id, 0.0))))
+            selected.append((aid, cat_id, float(thetas.get(cat_id, 0.0)), False))
 
-    # 6. quota 부족 → weighted random backfill
+    # 6. quota 부족 → weighted random backfill (이 row 들은 backfilled=true)
+    response_was_backfilled = False
     if len(selected) < N_RESULTS:
         _request_metrics["backfilled"] += 1
+        response_was_backfilled = True
         for aid, cid in _backfill(db, N_RESULTS - len(selected), seen, lang, rng):
             theta = float(thetas.get(cid, 0.0)) if cid is not None else 0.0
-            selected.append((aid, cid, theta))
+            selected.append((aid, cid, theta, True))
             seen.add(aid)
 
-    # in-response shuffle
     rng.shuffle(selected)
 
-    # 7. impression log (member_id 또는 device_id, feed_request_id)
+    # 7. impression log + latency (응답 단위 메트릭은 동일 latency_ms, 모든 row 동일 feed_request_id)
+    latency_ms = int((time.perf_counter() - started) * 1000)
     impression_rows = [
-        (aid, cid, pos + 1, theta)
-        for pos, (aid, cid, theta) in enumerate(selected)
+        (aid, cid, pos + 1, theta, was_bf)
+        for pos, (aid, cid, theta, was_bf) in enumerate(selected)
     ]
     log_impressions(
         db,
@@ -288,10 +290,12 @@ def _serve(
         device_id=device_id,
         feed_request_id=feed_request_id,
         rows=impression_rows,
+        latency_ms=latency_ms,
     )
 
-    _record_latency((time.perf_counter() - started) * 1000)
-    return RecommendItem(articles=[aid for aid, _, _ in selected], feed_request_id=feed_request_id)
+    _record_latency(latency_ms)
+    _ = response_was_backfilled  # 응답 단위 flag 는 admin/diagnostics 누적 카운터로만 사용
+    return RecommendItem(articles=[aid for aid, _, _, _ in selected], feed_request_id=feed_request_id)
 
 
 def recommend_feeds(

--- a/app/services/bandit.py
+++ b/app/services/bandit.py
@@ -38,9 +38,15 @@ REWARD_BETA: Dict[str, float] = {
 # softmax temperature — 높을수록 quota 가 평탄해져 winner-take-all 완화 (serendipity ↑).
 QUOTA_TEMPERATURE = 1.5
 
-# 비회원 prior — onboarding 정보 없으니 균등.
+# 비회원 prior — interest_ids 미제공 시 균등.
 DEVICE_PRIOR_ALPHA = 1.0
 DEVICE_PRIOR_BETA = 1.0
+# X-Interest-Ids 헤더로 들어온 카테고리: 회원 onboarding 보다 약간 약한 prior
+# (회원: Beta(4,1) — 명시 가입 + 동의 / 비회원: Beta(2,1) — UI 클릭 한번이라 신뢰 약함).
+DEVICE_PRIOR_ALPHA_INTEREST = 2.0
+DEVICE_PRIOR_BETA_INTEREST = 1.0
+DEVICE_PRIOR_ALPHA_NON_INTEREST = 1.0
+DEVICE_PRIOR_BETA_NON_INTEREST = 2.0
 
 
 @dataclass
@@ -200,13 +206,28 @@ def _fetch_existing_device_state(db: Session, device_id: str) -> Dict[int, Devic
     }
 
 
-def _lazy_init_device(db: Session, device_id: str, categories: Iterable[int]) -> Dict[int, DeviceBanditRow]:
-    """device_category_bandit 에 prior(균등 Beta(1,1))로 row 채워넣고 반환."""
+def _lazy_init_device(
+    db: Session,
+    device_id: str,
+    categories: Iterable[int],
+    interest_ids: Optional[Iterable[int]] = None,
+) -> Dict[int, DeviceBanditRow]:
+    """device_category_bandit 에 prior 로 row 채워넣고 반환.
+
+    interest_ids 가 주어지면 해당 카테고리는 Beta(2,1), 그 외는 Beta(1,2). 미제공 시 균등 Beta(1,1).
+    """
+    interest_set = set(int(c) for c in interest_ids) if interest_ids else None
     rows: List[Dict] = []
     out: Dict[int, DeviceBanditRow] = {}
     for cid in categories:
-        rows.append({"d": device_id, "c": int(cid), "a": DEVICE_PRIOR_ALPHA, "b": DEVICE_PRIOR_BETA})
-        out[int(cid)] = DeviceBanditRow(device_id, int(cid), DEVICE_PRIOR_ALPHA, DEVICE_PRIOR_BETA)
+        if interest_set is None:
+            a, b = DEVICE_PRIOR_ALPHA, DEVICE_PRIOR_BETA
+        elif cid in interest_set:
+            a, b = DEVICE_PRIOR_ALPHA_INTEREST, DEVICE_PRIOR_BETA_INTEREST
+        else:
+            a, b = DEVICE_PRIOR_ALPHA_NON_INTEREST, DEVICE_PRIOR_BETA_NON_INTEREST
+        rows.append({"d": device_id, "c": int(cid), "a": a, "b": b})
+        out[int(cid)] = DeviceBanditRow(device_id, int(cid), a, b)
 
     if rows:
         db.execute(
@@ -223,8 +244,12 @@ def _lazy_init_device(db: Session, device_id: str, categories: Iterable[int]) ->
     return out
 
 
-def load_or_init_device(db: Session, device_id: str) -> Dict[int, BanditRow]:
-    """비회원 device 의 (device_id, category_id) state 보장. 인터페이스 호환을 위해 BanditRow 형태로 반환."""
+def load_or_init_device(
+    db: Session,
+    device_id: str,
+    interest_ids: Optional[Iterable[int]] = None,
+) -> Dict[int, BanditRow]:
+    """비회원 device 의 (device_id, category_id) state 보장. interest_ids 는 lazy init 시 prior 결정에만 사용 (이미 row 있으면 무시)."""
     pool_categories = _fetch_pool_categories(db)
     if not pool_categories:
         return {}
@@ -232,15 +257,60 @@ def load_or_init_device(db: Session, device_id: str) -> Dict[int, BanditRow]:
     existing = _fetch_existing_device_state(db, device_id)
     missing = [c for c in pool_categories if c not in existing]
     if missing:
-        new_rows = _lazy_init_device(db, device_id, missing)
+        new_rows = _lazy_init_device(db, device_id, missing, interest_ids)
         existing.update(new_rows)
 
-    # member_id 자리에 0 (sentinel) 두고 BanditRow 로 변환 — sample_thetas / allocate_quota 재사용.
+    # member_id 자리에 0 (sentinel) — sample_thetas / allocate_quota 재사용.
     return {
         cid: BanditRow(member_id=0, category_id=cid, alpha=existing[cid].alpha, beta=existing[cid].beta)
         for cid in pool_categories
         if cid in existing
     }
+
+
+def migrate_device_to_member(db: Session, device_id: str, member_id: int) -> int:
+    """lazy guest 발급 직후 device_category_bandit → member_category_bandit 이관.
+
+    device 가 ground-truth (impression/click 누적). 회원의 새 row 가 prior 만 있으면
+    device 값으로 덮어씀 (해당 (member, category) row 없으면 INSERT).
+    이관 후 device 흔적은 보존 (분석용) — 추후 retention 정책에 따라 정리.
+    Returns 이관 row 수.
+    """
+    rows = db.execute(
+        text("SELECT category_id, alpha, beta, impressions, clicks FROM device_category_bandit WHERE device_id = :d"),
+        {"d": device_id},
+    ).all()
+    if not rows:
+        return 0
+
+    payload = [
+        {
+            "m": int(member_id),
+            "c": int(r[0]),
+            "a": float(r[1]),
+            "b": float(r[2]),
+            "imp": int(r[3]),
+            "clk": int(r[4]),
+        }
+        for r in rows
+    ]
+    db.execute(
+        text(
+            """
+            INSERT INTO member_category_bandit
+                (member_id, category_id, alpha, beta, impressions, clicks)
+            VALUES (:m, :c, :a, :b, :imp, :clk)
+            ON DUPLICATE KEY UPDATE
+                alpha = VALUES(alpha),
+                beta = VALUES(beta),
+                impressions = member_category_bandit.impressions + VALUES(impressions),
+                clicks = member_category_bandit.clicks + VALUES(clicks)
+            """
+        ),
+        payload,
+    )
+    db.commit()
+    return len(payload)
 
 
 def apply_reward_device(db: Session, device_id: str, category_id: int, event_type: str) -> None:

--- a/app/services/bandit.py
+++ b/app/services/bandit.py
@@ -272,34 +272,18 @@ def migrate_device_to_member(db: Session, device_id: str, member_id: int) -> int
     """lazy guest 발급 직후 device_category_bandit → member_category_bandit 이관.
 
     device 가 ground-truth (impression/click 누적). 회원의 새 row 가 prior 만 있으면
-    device 값으로 덮어씀 (해당 (member, category) row 없으면 INSERT).
+    device 값으로 덮어씀. 단일 INSERT ... SELECT — round-trip 1회.
     이관 후 device 흔적은 보존 (분석용) — 추후 retention 정책에 따라 정리.
-    Returns 이관 row 수.
+    Returns 이관 row 수 (driver rowcount).
     """
-    rows = db.execute(
-        text("SELECT category_id, alpha, beta, impressions, clicks FROM device_category_bandit WHERE device_id = :d"),
-        {"d": device_id},
-    ).all()
-    if not rows:
-        return 0
-
-    payload = [
-        {
-            "m": int(member_id),
-            "c": int(r[0]),
-            "a": float(r[1]),
-            "b": float(r[2]),
-            "imp": int(r[3]),
-            "clk": int(r[4]),
-        }
-        for r in rows
-    ]
-    db.execute(
+    result = db.execute(
         text(
             """
             INSERT INTO member_category_bandit
                 (member_id, category_id, alpha, beta, impressions, clicks)
-            VALUES (:m, :c, :a, :b, :imp, :clk)
+            SELECT :m, category_id, alpha, beta, impressions, clicks
+            FROM device_category_bandit
+            WHERE device_id = :d
             ON DUPLICATE KEY UPDATE
                 alpha = VALUES(alpha),
                 beta = VALUES(beta),
@@ -307,10 +291,12 @@ def migrate_device_to_member(db: Session, device_id: str, member_id: int) -> int
                 clicks = member_category_bandit.clicks + VALUES(clicks)
             """
         ),
-        payload,
+        {"m": int(member_id), "d": device_id},
     )
     db.commit()
-    return len(payload)
+    # rowcount: ON DUPLICATE KEY UPDATE 는 INSERT 시 1, UPDATE 시 2 를 더하므로 정확한 row 수 아님.
+    # 정확한 source row 수가 꼭 필요하면 별도 SELECT COUNT 로 가능 — 현재는 진단용이라 raw rowcount 그대로.
+    return int(result.rowcount or 0)
 
 
 def apply_reward_device(db: Session, device_id: str, category_id: int, event_type: str) -> None:

--- a/app/services/impression_logger.py
+++ b/app/services/impression_logger.py
@@ -3,6 +3,7 @@
 응답 직전 동기 INSERT (latency 안 큼: 10 row, single tx). 실패는 graceful skip.
 member_id 또는 device_id 둘 중 하나는 NOT NULL (app 단 가드).
 feed_request_id 는 같은 응답의 모든 row 가 공유 — impression ↔ click 정확 그룹핑.
+was_backfilled / latency_ms 는 같은 feed_request_id 의 모든 row 에 동일 (응답 단위 메트릭).
 """
 from __future__ import annotations
 
@@ -20,15 +21,17 @@ def log_impressions(
     member_id: Optional[int],
     device_id: Optional[str],
     feed_request_id: Optional[str],
-    rows: Iterable[Tuple[str, Optional[int], int, Optional[float]]],
+    rows: Iterable[Tuple[str, Optional[int], int, Optional[float], bool]],
+    latency_ms: Optional[int] = None,
 ) -> int:
-    """rows: (article_id, category_id, position, bandit_theta) iterable. position 은 1..N."""
+    """rows: (article_id, category_id, position, bandit_theta, was_backfilled). position 은 1..N (1-base)."""
     if member_id is None and not device_id:
         log.warning("impression log: both member_id and device_id missing — skip")
         return 0
 
     mid = int(member_id) if member_id is not None else None
     did = str(device_id) if device_id else None
+    lat = int(latency_ms) if latency_ms is not None else None
     payload: List[dict] = [
         {
             "m": mid,
@@ -38,8 +41,10 @@ def log_impressions(
             "p": int(position),
             "t": float(theta) if theta is not None else None,
             "fr": feed_request_id,
+            "bf": 1 if was_backfilled else 0,
+            "lat": lat,
         }
-        for article_id, category_id, position, theta in rows
+        for article_id, category_id, position, theta, was_backfilled in rows
     ]
     if not payload:
         return 0
@@ -49,8 +54,9 @@ def log_impressions(
             text(
                 """
                 INSERT INTO recommendation_impression
-                    (member_id, device_id, article_id, category_id, position, feed_request_id, bandit_theta)
-                VALUES (:m, :d, :a, :c, :p, :fr, :t)
+                    (member_id, device_id, article_id, category_id, position,
+                     feed_request_id, bandit_theta, was_backfilled, latency_ms)
+                VALUES (:m, :d, :a, :c, :p, :fr, :t, :bf, :lat)
                 """
             ),
             payload,


### PR DESCRIPTION
회피 항목 2+3+4+6. anonymous device prior 강화 (Beta(2,1)/(1,2)), POST /feeds/migrate-device (단일 INSERT...SELECT), impression 에 was_backfilled+latency_ms 적재. simplify: dead path 제거, X-Interest-Ids const.