### PR TITLE
feat(search): disable popular-query suggest by default (SEARCH_POPULAR_ENABLED flag)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -42,6 +42,10 @@ class Config(BaseSettings):
     REDIS_CACHE_NAMESPACE: str = "search:emb:"
     REDIS_POPULAR_KEY: str = "search:popular"
     REDIS_POPULAR_TTL: int = 60 * 60 * 24 * 30  # 30 days
+    # Popular-query auto-suggest. Off by default — single-occurrence noise
+    # ranks the same as legitimate trending queries with no cutoff or
+    # moderation. Re-enable only with curation in place.
+    SEARCH_POPULAR_ENABLED: bool = False
 
     # Drift monitoring — 색인 측 SentenceTransformer ↔ 쿼리 측 ONNX parity check
     DRIFT_ENABLED: bool = True

--- a/app/services/popular_queries.py
+++ b/app/services/popular_queries.py
@@ -29,6 +29,8 @@ def _normalize(query: str) -> str:
 
 
 def record(query: str) -> None:
+    if not config.SEARCH_POPULAR_ENABLED:
+        return
     norm = _normalize(query)
     if not norm or len(norm) > 200:
         return
@@ -53,6 +55,8 @@ def record(query: str) -> None:
 
 def suggest(prefix: str, limit: int = 8) -> List[str]:
     """prefix로 시작하는 인기 검색어 top-N 반환 (count desc)."""
+    if not config.SEARCH_POPULAR_ENABLED:
+        return []
     norm = _normalize(prefix)
     if not norm:
         # 빈 prefix면 전역 인기 검색어
@@ -86,6 +90,8 @@ def suggest(prefix: str, limit: int = 8) -> List[str]:
 
 
 def top(limit: int = 8) -> List[str]:
+    if not config.SEARCH_POPULAR_ENABLED:
+        return []
     client = redis_client.get_client()
     if client is not None:
         try:

--- a/tests/test_popular_queries.py
+++ b/tests/test_popular_queries.py
@@ -1,4 +1,15 @@
+import pytest
+
+from app.core.config import config
 from app.services import popular_queries, redis_client
+
+
+@pytest.fixture(autouse=True)
+def _enable_popular_queries():
+    original = config.SEARCH_POPULAR_ENABLED
+    config.SEARCH_POPULAR_ENABLED = True
+    yield
+    config.SEARCH_POPULAR_ENABLED = original
 
 
 def setup_function(_):
@@ -7,6 +18,13 @@ def setup_function(_):
 
 def teardown_module(_):
     redis_client.reset()
+
+
+def test_disabled_short_circuits():
+    config.SEARCH_POPULAR_ENABLED = False
+    popular_queries.record("kubernetes")
+    assert popular_queries.suggest("k", limit=10) == []
+    assert popular_queries.top(10) == []
 
 
 def test_record_increments_count():


### PR DESCRIPTION
## Summary
- 검색 자동완성이 사용자 검색 누적 popularity 기반인데 단일 키스트로크 노이즈도 그대로 노출 (현재 \`ㅅ\`, \`zxcvbnmqazwsx...\` 등 운영 데이터에 섞여 있음)
- 큐레이션/cutoff 도입 전까지 위험하므로 \`SEARCH_POPULAR_ENABLED\` flag (default False) 로 일괄 차단
- \`record/suggest/top\` 모두 flag 단락 — Redis 미접속, 프론트는 빈 list 받아 suggestions UI 자동 숨김

## Test plan
- [x] uv run pytest tests/test_popular_queries.py 통과 (6 tests)
- [x] uv run pytest 전체 통과 (52 tests)
- [ ] 머지 후 운영에서 \`/v1/articles/suggest?q=k\` 빈 list 응답 확인
- [ ] Redis \`search:popular\` key DEL 로 누적 노이즈 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)